### PR TITLE
basic support for comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 zig-cache/
+zig-out/


### PR DESCRIPTION
Adds support for xml with multi-line xml comments by naively skipping them - doesn't handle nested comments because I'm not parsing xml with those